### PR TITLE
Additionally monitor moved_to event

### DIFF
--- a/go-reload
+++ b/go-reload
@@ -3,7 +3,7 @@
 # Watch all *.go files in the specified directory
 # Call the restart function when they are saved
 function monitor() {
-  inotifywait -q -m -r -e close_write --exclude '[^g][^o]$' $1 |
+  inotifywait -q -m -r -e close_write -e moved_to --exclude '[^g][^o]$' $1 |
   while read line; do
     restart
   done


### PR DESCRIPTION
Sublime Text uses temp files and move operations to atomically change a file's contents. This is unmatched by the close_write method and so we should monitor moves as well.
